### PR TITLE
Fix off-screen check in minimum tap area checker

### DIFF
--- a/lib/src/checkers/checker_base.dart
+++ b/lib/src/checkers/checker_base.dart
@@ -60,15 +60,6 @@ extension RenderObjectExtension on RenderObject {
     final offset = Offset(translation.x, translation.y);
     return paintBounds.shift(offset);
   }
-
-  Element? getCreatorElement() {
-    final creator = debugCreator;
-    if (creator is DebugCreator) {
-      return creator.element;
-    }
-
-    return null;
-  }
 }
 
 extension SemanticsDataExtension on SemanticsData {

--- a/lib/src/checkers/minimum_tap_area_checker.dart
+++ b/lib/src/checkers/minimum_tap_area_checker.dart
@@ -99,12 +99,8 @@ should be at least ${format(minTapArea)}x${format(minTapArea)}''',
   }
 
   /// Returns true if rectange of a node is (partially) off screen
-  bool _isNodeOffScreen(
-    Rect paintBounds,
-    FlutterView window, {
-    double delta = 10.0,
-  }) {
-    assert(delta >= 0, 'Delta must not be negative');
+  bool _isNodeOffScreen(Rect paintBounds, FlutterView window) {
+    const delta = 10.0;
     final Size windowPhysicalSize =
         window.physicalSize * window.devicePixelRatio;
     return paintBounds.top < -delta ||

--- a/lib/src/checkers/minimum_tap_area_checker.dart
+++ b/lib/src/checkers/minimum_tap_area_checker.dart
@@ -107,7 +107,6 @@ should be at least ${format(minTapArea)}x${format(minTapArea)}''',
     assert(delta >= 0, 'Delta must not be negative');
     final Size windowPhysicalSize =
         window.physicalSize * window.devicePixelRatio;
-    print(paintBounds);
     return paintBounds.top < -delta ||
         paintBounds.left < -delta ||
         paintBounds.bottom > windowPhysicalSize.height + delta ||

--- a/lib/src/checkers/minimum_tap_area_checker.dart
+++ b/lib/src/checkers/minimum_tap_area_checker.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -67,16 +68,13 @@ class MinimumTapAreaChecker extends SemanticsNodeChecker {
     }
 
     final paintBounds = getPaintBounds(node);
-    final devicePixelRatio = WidgetsBinding.instance.window.devicePixelRatio;
-    final size = paintBounds.size / devicePixelRatio;
-    final element = renderObject.getCreatorElement();
+    final window = WidgetsBinding.instance.window;
 
-    if (element?.size != null && element?.size != size) {
-      // Item size doesn't match tap area height - it's probably partially off
-      // screen
+    if (_isNodeOffScreen(paintBounds, window)) {
       return null;
     }
 
+    final size = paintBounds.size / window.devicePixelRatio;
     const delta = 0.001;
     if (size.width < minTapArea - delta || size.height < minTapArea - delta) {
       return AccessibilityIssue(
@@ -98,5 +96,21 @@ should be at least ${format(minTapArea)}x${format(minTapArea)}''',
     return (rounded - rounded.toInt()) == 0
         ? rounded.toStringAsFixed(0)
         : rounded.toStringAsFixed(2);
+  }
+
+  /// Returns true if rectange of a node is (partially) off screen
+  bool _isNodeOffScreen(
+    Rect paintBounds,
+    FlutterView window, {
+    double delta = 10.0,
+  }) {
+    assert(delta >= 0, 'Delta must not be negative');
+    final Size windowPhysicalSize =
+        window.physicalSize * window.devicePixelRatio;
+    print(paintBounds);
+    return paintBounds.top < -delta ||
+        paintBounds.left < -delta ||
+        paintBounds.bottom > windowPhysicalSize.height + delta ||
+        paintBounds.right > windowPhysicalSize.width + delta;
   }
 }

--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -150,6 +150,158 @@ ${getWidgetLocationDescription(tester, find.byType(ElevatedButton))}
     expect(tapAreas.forPlatform(TargetPlatform.linux), desktopValue);
   });
 
+  testWidgets("Doesn't show warning for offscreen widget", (tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(500, 500);
+
+    final key = UniqueKey();
+    await tester.pumpWidget(
+      TestApp(
+        minimumTapAreas: const MinimumTapAreas(desktop: 0, mobile: 100),
+        child: Transform.translate(
+          offset: const Offset(-10000, -10000),
+          child: SizedBox(
+            width: 50,
+            height: 50,
+            child: GestureDetector(
+              key: key,
+              child: const Text('Tap area'),
+              onTap: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.accessibility_new), findsNothing);
+    expect(find.byWidgetPredicate((w) => w is Tooltip), findsNothing);
+  });
+
+  testWidgets(
+    'Shows warning for a small tap area when widget is partially visible',
+    (WidgetTester tester) async {
+      tester.binding.window.physicalSizeTestValue = const Size(500, 500);
+
+      final key = UniqueKey();
+      await tester.pumpWidget(
+        TestApp(
+          minimumTapAreas: const MinimumTapAreas(desktop: 0, mobile: 100),
+          child: Transform.translate(
+            offset: const Offset(-60, -60),
+            child: Center(
+              child: SizedBox(
+                width: 50,
+                height: 50,
+                child: GestureDetector(
+                  key: key,
+                  child: const Text('Tap area'),
+                  onTap: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await showAccessibilityIssues(tester);
+      expectAccessibilityWarning(
+        tester,
+        erroredWidgetFinder: find.byKey(key),
+        tooltipMessage:
+            'Tap area of 50x50 is too small:\nshould be at least 100x100',
+      );
+    },
+  );
+
+  testWidgets(
+    'Shows warning for a small tap area when size is a floating point number',
+    (WidgetTester tester) async {
+      final key = UniqueKey();
+      await tester.pumpWidget(
+        TestApp(
+          minimumTapAreas: const MinimumTapAreas(desktop: 0, mobile: 100),
+          child: SizedBox(
+            width: 99.3,
+            height: 99.3,
+            child: GestureDetector(
+              key: key,
+              child: const Text('Tap area'),
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      await showAccessibilityIssues(tester);
+      expectAccessibilityWarning(
+        tester,
+        erroredWidgetFinder: find.byKey(key),
+        tooltipMessage:
+            'Tap area of 99.30x99.30 is too small:\nshould be at least 100x100',
+      );
+    },
+  );
+
+  testWidgets(
+    'Shows warning for a small tap area when size is an irrational number',
+    (WidgetTester tester) async {
+      final key = UniqueKey();
+      await tester.pumpWidget(
+        TestApp(
+          minimumTapAreas: const MinimumTapAreas(desktop: 0, mobile: 100),
+          child: SizedBox(
+            width: 100 / 3,
+            height: 100 / 6,
+            child: GestureDetector(
+              key: key,
+              child: const Text('Tap area'),
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      await showAccessibilityIssues(tester);
+      expectAccessibilityWarning(
+        tester,
+        erroredWidgetFinder: find.byKey(key),
+        tooltipMessage: 'Tap area of 33.33x16.67 is too small:'
+            '\nshould be at least 100x100',
+      );
+    },
+  );
+
+  testWidgets(
+    'Shows warning for a small tap area when pixel ratio is not an integer',
+    (WidgetTester tester) async {
+      tester.binding.window.devicePixelRatioTestValue = 1.333;
+
+      final key = UniqueKey();
+      await tester.pumpWidget(
+        TestApp(
+          minimumTapAreas: const MinimumTapAreas(desktop: 0, mobile: 100),
+          child: SizedBox(
+            width: 99,
+            height: 99,
+            child: GestureDetector(
+              key: key,
+              child: const Text('Tap area'),
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      await showAccessibilityIssues(tester);
+      expectAccessibilityWarning(
+        tester,
+        erroredWidgetFinder: find.byKey(key),
+        tooltipMessage:
+            'Tap area of 99x99 is too small:\nshould be at least 100x100',
+      );
+    },
+  );
+
   test(
     'Formatted size is not too long (max 2 places after decimal point)',
     () {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -67,10 +67,10 @@ ${debugWarningBoxesText(tester)}''',
   const borderSize = 5.0;
 
   // Verify size of warning box
-  expect(
-    warningBox.size,
-    buttonRenderBox.size + const Offset(borderSize, borderSize),
-  );
+  const delta = Offset(0.001, 0.001);
+  final buttonBox = buttonRenderBox.size + const Offset(borderSize, borderSize);
+  final sizeDiff = warningBox.size - buttonBox;
+  expect(sizeDiff, lessThan(delta));
 
   final errorBoxPosition = warningBox.localToGlobal(
     warningBox.size.center(Offset.zero),


### PR DESCRIPTION
This pull request fixes off-screen node check in minimum tap area checker. Now screen size is compared to node's rectangle to check if node is off-screen. This removes calculations with doubles which were failing in some cases (like in #23).

Closes #23