### PR TITLE
Fix accessibility tools not able to find issues

### DIFF
--- a/lib/src/checker_manager.dart
+++ b/lib/src/checker_manager.dart
@@ -23,12 +23,6 @@ class CheckerManager extends ChangeNotifier {
 
   /// Called whenever the semantic tree updates.
   void update() {
-    final root =
-        WidgetsBinding.instance.pipelineOwner.semanticsOwner?.rootSemanticsNode;
-    if (root == null) {
-      return;
-    }
-
     final renderObjects = _getRenderObjectsWithSemantics();
 
     for (final checker in checkers) {

--- a/lib/src/checkers/flex_overflow_checker.dart
+++ b/lib/src/checkers/flex_overflow_checker.dart
@@ -78,7 +78,9 @@ class _FlexOverflowCheckerInjectorState
       children: [
         MediaQuery(
           data: MediaQuery.of(context).copyWith(
-            textScaleFactor: _textScaleFactor,
+            textScaler: _textScaleFactor != null
+                ? TextScaler.linear(_textScaleFactor!)
+                : null,
           ),
           child: widget.child,
         ),

--- a/lib/src/checkers/mixin.dart
+++ b/lib/src/checkers/mixin.dart
@@ -3,18 +3,29 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 mixin SemanticUpdateMixin<T extends StatefulWidget> on State<T> {
-  late final SemanticsClient client;
+  late final List<SemanticsClient> _clients = [];
+  late final SemanticsHandle _rootSemanticsHandle;
 
   @override
   void initState() {
-    client = SemanticsClient(WidgetsBinding.instance.pipelineOwner)
-      ..addListener(_update);
+    _rootSemanticsHandle = RendererBinding.instance.ensureSemantics();
+
+    RendererBinding.instance.rootPipelineOwner.visitChildren((child) {
+      final client = SemanticsClient(child)..addListener(_update);
+      _clients.add(client);
+    });
+
     super.initState();
   }
 
   @override
   void dispose() {
-    client.dispose();
+    _rootSemanticsHandle.dispose();
+
+    for (final client in _clients) {
+      client.dispose();
+    }
+
     super.dispose();
   }
 


### PR DESCRIPTION
Fix #37

Recent changes in Flutter 3.16 are causing accessibility tools to show no issues. The root cause seems to be the deprecation of `WidgetsBinding.pipelineOwner` and some internal changes in semantic listeners
