### PR TITLE
Fix off-screen widget check

### DIFF
--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -325,6 +325,51 @@ Icon(
     },
   );
 
+  testWidgets(
+    "Doesn't show warnings for partially off-screen widgets inside scrollable",
+    (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+
+      final log = await recordDebugPrint(() async {
+        await tester.pumpWidget(
+          TestApp(
+            minimumTapAreas: const MinimumTapAreas(desktop: 25, mobile: 25),
+            child: ListView(
+              // Make sure big part of the blue widget is off-screen. The visible
+              // part is still clickable and doesn't meet min tap area
+              // requirements
+              controller: ScrollController(initialScrollOffset: 80),
+              padding: EdgeInsets.zero,
+              children: [
+                GestureDetector(
+                  onTap: () {},
+                  child: Semantics(
+                    label: 'Label',
+                    child: Container(
+                      color: Colors.blue,
+                      height: 100,
+                    ),
+                  ),
+                ),
+                Container(
+                  width: 10,
+                  height: 10000,
+                  color: Colors.white,
+                ),
+              ],
+            ),
+          ),
+        );
+      });
+
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.accessibility_new), findsNothing);
+      expect(find.byWidgetPredicate((w) => w is Tooltip), findsNothing);
+      expect(log, isEmpty);
+    },
+  );
+
   test(
     'Formatted size is not too long (max 2 places after decimal point)',
     () {

--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -335,9 +335,9 @@ Icon(
           TestApp(
             minimumTapAreas: const MinimumTapAreas(desktop: 25, mobile: 25),
             child: ListView(
-              // Make sure big part of the blue widget is off-screen. The visible
-              // part is still clickable and doesn't meet min tap area
-              // requirements
+              // Make sure big part of the blue widget is off-screen.
+              // The visible part is still clickable and doesn't meet min tap
+              // area requirements
               controller: ScrollController(initialScrollOffset: 80),
               padding: EdgeInsets.zero,
               children: [


### PR DESCRIPTION
This pull request restores a size check that was replaced by a different check in #28. The off-screen check is now compares node and render object's sizes _and_ node paint bounds.

This fixes an issue when tappable widget is placed in a scrolling container and is partially off-screen (#31)