### PR TITLE
Create image label checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Add accessibility checker for images without labels
+
 ## 2.0.0
 
 * Add accessibility testing tools, a panel with toggles to help testing app behavior in different conditions

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Experimental: ensures that no flex widgets, such as `Column` and `Row`, overflow
 
 Makes sure text fields (`TextField`, `TextFormField`, `Autocomplete` etc) and inputs (`Checkbox`, `Radio`, `Switch` etc) have semantic labels.
 
+### Image label checker
+
+Makes sure images have semantic labels.
+
 ## Current testing tools toggles
 
 * Text scale. Changes text scale factor, range is 0.1 to 10.0. Does nothing if app ignores text scaling
@@ -91,6 +95,8 @@ AccessibilityTools(
   checkSemanticLabels: false,
   // Check for flex overflows
   checkFontOverflows: true,
+  // Check for image labels
+  checkImageLabels: true,
   // Set how much info about issues is printed
   logLevel: LogLevel.verbose,
   child: child,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,6 +19,7 @@ class MyApp extends StatelessWidget {
         // only in debug mode
         return AccessibilityTools(
           checkFontOverflows: true,
+          checkImageLabels: true,
           child: child,
         );
       },

--- a/lib/src/accessibility_tools.dart
+++ b/lib/src/accessibility_tools.dart
@@ -50,7 +50,7 @@ class AccessibilityTools extends StatefulWidget {
     this.checkSemanticLabels = true,
     this.checkMissingInputLabels = true,
     this.checkFontOverflows = false,
-    this.checkImageLabels = false,
+    this.checkImageLabels = true,
   });
 
   /// Forces accessibility checkers to run when running from a test.

--- a/lib/src/accessibility_tools.dart
+++ b/lib/src/accessibility_tools.dart
@@ -11,6 +11,7 @@ import 'accessibility_issue.dart';
 import 'checker_manager.dart';
 import 'checkers/checker_base.dart';
 import 'checkers/flex_overflow_checker.dart';
+import 'checkers/image_label_checker.dart';
 import 'checkers/input_label_checker.dart';
 import 'checkers/minimum_tap_area_checker.dart';
 import 'checkers/mixin.dart';
@@ -49,6 +50,7 @@ class AccessibilityTools extends StatefulWidget {
     this.checkSemanticLabels = true,
     this.checkMissingInputLabels = true,
     this.checkFontOverflows = false,
+    this.checkImageLabels = false,
   });
 
   /// Forces accessibility checkers to run when running from a test.
@@ -61,6 +63,7 @@ class AccessibilityTools extends StatefulWidget {
   final bool checkSemanticLabels;
   final bool checkFontOverflows;
   final bool checkMissingInputLabels;
+  final bool checkImageLabels;
 
   @override
   State<AccessibilityTools> createState() => _AccessibilityToolsState();
@@ -119,6 +122,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
           textScaleFactor: iOSLargestTextScaleFactor,
         ),
       if (widget.checkMissingInputLabels) InputLabelChecker(),
+      if (widget.checkImageLabels) ImageLabelChecker(),
     ];
   }
 

--- a/lib/src/checkers/checker_base.dart
+++ b/lib/src/checkers/checker_base.dart
@@ -73,4 +73,8 @@ extension SemanticsDataExtension on SemanticsData {
         hasFlag(SemanticsFlag.hasCheckedState) ||
         hasFlag(SemanticsFlag.hasToggledState);
   }
+
+  bool get isImage {
+    return hasFlag(SemanticsFlag.isImage);
+  }
 }

--- a/lib/src/checkers/image_label_checker.dart
+++ b/lib/src/checkers/image_label_checker.dart
@@ -21,28 +21,7 @@ class ImageLabelChecker extends SemanticsNodeChecker {
     final hasLabel = data.label.trim().isNotEmpty;
     if (hasLabel) return null;
 
-    if (node.hasFlag(SemanticsFlag.isImage)) {
-      return _getImageIssue(renderObject);
-    }
-
-    return _getDefaultIssue(renderObject);
-  }
-
-  AccessibilityIssue _getDefaultIssue(RenderObject renderObject) {
-    return AccessibilityIssue(
-      message: 'Image widget is missing a semantic label.',
-      resolutionGuidance: '''
-Consider adding a label to the widgets if it allows or using the Semantics
-widget to provide a label:
-
-  Semantics(
-    label: 'Show password',
-    child: MyWidget(),
-  )
-
-''',
-      renderObject: renderObject,
-    );
+    return _getImageIssue(renderObject);
   }
 
   AccessibilityIssue _getImageIssue(RenderObject renderObject) {

--- a/lib/src/checkers/image_label_checker.dart
+++ b/lib/src/checkers/image_label_checker.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+import '../accessibility_issue.dart';
+import 'checker_base.dart';
+
+/// Checks whether image widgets have a label. Label must not be empty or blank
+/// to pass this check.
+class ImageLabelChecker extends SemanticsNodeChecker {
+  @override
+  AccessibilityIssue? checkNode(SemanticsNode node, RenderObject renderObject) {
+    if (node.isMergedIntoParent ||
+        node.isInvisible ||
+        node.hasFlag(SemanticsFlag.isHidden)) {
+      return null;
+    }
+
+    final data = node.getSemanticsData();
+    if (!data.isImage) return null;
+
+    final hasLabel = data.label.trim().isNotEmpty;
+    if (hasLabel) return null;
+
+    if (node.hasFlag(SemanticsFlag.isImage)) {
+      return _getImageIssue(renderObject);
+    }
+
+    return _getDefaultIssue(renderObject);
+  }
+
+  AccessibilityIssue _getDefaultIssue(RenderObject renderObject) {
+    return AccessibilityIssue(
+      message: 'Image widget is missing a semantic label.',
+      resolutionGuidance: '''
+Consider adding a label to the widgets if it allows or using the Semantics
+widget to provide a label:
+
+  Semantics(
+    label: 'Show password',
+    child: MyWidget(),
+  )
+
+''',
+      renderObject: renderObject,
+    );
+  }
+
+  AccessibilityIssue _getImageIssue(RenderObject renderObject) {
+    return AccessibilityIssue(
+      message: 'Image widget is missing a semantic label.',
+      resolutionGuidance: '''
+Consider adding a semantic label to the image if it allows or using the Semantics
+widget to provide a label:
+
+  Image.asset(
+    'assets/image.png',
+    semanticLabel: 'Show password',
+  )
+
+''',
+      renderObject: renderObject,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: accessibility_tools
 description: Checkers and tools to ensure your app is accessible to all. Ensures your app is accessible from day one, by checking your interface as you build it.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/rebelappstudio/accessibility_tools/
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,5 +14,8 @@ dependencies:
   flutter_test:
     sdk: flutter
 
+dev_dependencies: 
+  network_image_mock: ^2.1.1
+
 flutter:
   uses-material-design: true

--- a/test/semantic_label_checker_test.dart
+++ b/test/semantic_label_checker_test.dart
@@ -1,6 +1,7 @@
 import 'package:accessibility_tools/src/accessibility_tools.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
 
 import 'test_utils.dart';
 
@@ -61,14 +62,18 @@ void main() {
     (WidgetTester tester) async {
       const imageKey = Key('Image');
 
-      await tester.pumpWidget(
-        TestApp(
-          child: Image.network(
-            'https://picsum.photos/200/200',
-            key: imageKey,
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(
+          TestApp(
+            child: Image.network(
+              'https://picsum.photos/200/200',
+              height: 200,
+              width: 200,
+              key: imageKey,
+            ),
           ),
-        ),
-      );
+        );
+      });
 
       await showAccessibilityIssues(tester);
 

--- a/test/semantic_label_checker_test.dart
+++ b/test/semantic_label_checker_test.dart
@@ -57,6 +57,30 @@ void main() {
   );
 
   testWidgets(
+    'Shows warning for Image without semantic label',
+    (WidgetTester tester) async {
+      const imageKey = Key('Image');
+
+      await tester.pumpWidget(
+        TestApp(
+          child: Image.network(
+            'https://picsum.photos/200/200',
+            key: imageKey,
+          ),
+        ),
+      );
+
+      await showAccessibilityIssues(tester);
+
+      expectAccessibilityWarning(
+        tester,
+        erroredWidgetFinder: find.byKey(imageKey),
+        tooltipMessage: 'Image widget is missing a semantic label.',
+      );
+    },
+  );
+
+  testWidgets(
     'Prints console warning for tap area without semantic label',
     (WidgetTester tester) async {
       final log = await recordDebugPrint(() async {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -32,6 +32,7 @@ class TestApp extends StatelessWidget {
       ],
       builder: (context, child) => AccessibilityTools(
         checkFontOverflows: true,
+        checkImageLabels: true,
         minimumTapAreas: minimumTapAreas,
         logLevel: logLevel,
         child: child,


### PR DESCRIPTION
Using the same logic for input label checker, created a new image label checker that checks if SemanticFlag isImage is on.

Also works on SvgPicture

Fix #45 