### PR TITLE
feature: IgnoreMinimumTapAreaSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Adding a semantic label would fix this: `Icon(Icons.person, semanticLabel: 'Logi
 
 Makes sure all tappable widgets are large enough to easily tap. Defaults to the [Material Design minimum](https://m3.material.io/foundations/accessible-design/accessibility-basics#28032e45-c598-450c-b355-f9fe737b1cd8) of 48x48 on mobile devices, and 44x44 on desktop devices.
 
+For exceptional cases (e.g. a button for each day in a calendar widget), tap area checker warnings can be 
+ignored by wrapping the corresponding widget with `IgnoreMinimumTapAreaSize`.
+
 ### Large font overflow checker
 
 Experimental: ensures that no flex widgets, such as `Column` and `Row`, overflow when a user is using larger font sizes. This checker is experimental, and disabled by default, and can be enabled via `AccessibilityTools(checkFontOverflows: true)`.

--- a/lib/accessibility_tools.dart
+++ b/lib/accessibility_tools.dart
@@ -1,6 +1,7 @@
 library accessibility_tools;
 
 export 'src/accessibility_tools.dart';
+export 'src/checkers/ignore_minimum_tap_area_size.dart';
 export 'src/checkers/minimum_tap_area_checker.dart' show MinimumTapAreas;
 export 'src/enums/buttons_alignment.dart';
 export 'src/testing_tools/testing_tools_configuration.dart';

--- a/lib/src/checkers/ignore_minimum_tap_area_size.dart
+++ b/lib/src/checkers/ignore_minimum_tap_area_size.dart
@@ -7,12 +7,13 @@ class IgnoreMinimumTapAreaSize extends InheritedWidget {
   });
 
   static IgnoreMinimumTapAreaSize? maybeOf(BuildContext context) {
-    return LookupBoundary.dependOnInheritedWidgetOfExactType<IgnoreMinimumTapAreaSize>(context);
+    return LookupBoundary.dependOnInheritedWidgetOfExactType<
+        IgnoreMinimumTapAreaSize>(context);
   }
 
   static IgnoreMinimumTapAreaSize of(BuildContext context) {
     final IgnoreMinimumTapAreaSize? result =
-    context.dependOnInheritedWidgetOfExactType<IgnoreMinimumTapAreaSize>();
+        context.dependOnInheritedWidgetOfExactType<IgnoreMinimumTapAreaSize>();
     assert(result != null, 'No IgnoreMinimumTapAreaSize found in context');
     return result!;
   }

--- a/lib/src/checkers/ignore_minimum_tap_area_size.dart
+++ b/lib/src/checkers/ignore_minimum_tap_area_size.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class IgnoreMinimumTapAreaSize extends InheritedWidget {
+  const IgnoreMinimumTapAreaSize({
+    super.key,
+    required super.child,
+  });
+
+  static IgnoreMinimumTapAreaSize? maybeOf(BuildContext context) {
+    return LookupBoundary.dependOnInheritedWidgetOfExactType<IgnoreMinimumTapAreaSize>(context);
+  }
+
+  static IgnoreMinimumTapAreaSize of(BuildContext context) {
+    final IgnoreMinimumTapAreaSize? result =
+    context.dependOnInheritedWidgetOfExactType<IgnoreMinimumTapAreaSize>();
+    assert(result != null, 'No IgnoreMinimumTapAreaSize found in context');
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(IgnoreMinimumTapAreaSize oldWidget) {
+    return false;
+  }
+}

--- a/lib/src/checkers/ignore_minimum_tap_area_size.dart
+++ b/lib/src/checkers/ignore_minimum_tap_area_size.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+/// When added to the widget tree, warnings caused by <code>MinimumTapAreaSizeChecker</code>
+/// are ignored for all descendants of this widget.
 class IgnoreMinimumTapAreaSize extends InheritedWidget {
   const IgnoreMinimumTapAreaSize({
     super.key,

--- a/lib/src/checkers/minimum_tap_area_checker.dart
+++ b/lib/src/checkers/minimum_tap_area_checker.dart
@@ -67,7 +67,9 @@ class MinimumTapAreaChecker extends SemanticsNodeChecker {
   AccessibilityIssue? checkNode(SemanticsNode node, RenderObject renderObject) {
     final window = _flutterViewForRenderObject(renderObject);
 
-    if (window == null || node.isMergedIntoParent || !node.getSemanticsData().isTappable) {
+    if (window == null ||
+        node.isMergedIntoParent ||
+        !node.getSemanticsData().isTappable) {
       return null;
     }
 
@@ -154,14 +156,16 @@ Icon(
     final widthDiff = (nodeSize.width - renderObjectSize.width).abs();
     final heightDiff = (nodeSize.height - renderObjectSize.height).abs();
     const offScreenDelta = 5.0;
-    final isNodeOffScreen = widthDiff >= offScreenDelta || heightDiff >= offScreenDelta;
+    final isNodeOffScreen =
+        widthDiff >= offScreenDelta || heightDiff >= offScreenDelta;
     if (isNodeOffScreen) {
       return true;
     }
 
     // Check if node's paint bounds are off screen
     const delta = 10.0;
-    final windowPhysicalSize = flutterView.physicalSize * flutterView.devicePixelRatio;
+    final windowPhysicalSize =
+        flutterView.physicalSize * flutterView.devicePixelRatio;
     return nodePaintBounds.top < -delta ||
         nodePaintBounds.left < -delta ||
         nodePaintBounds.bottom > windowPhysicalSize.height + delta ||

--- a/lib/src/checkers/minimum_tap_area_checker.dart
+++ b/lib/src/checkers/minimum_tap_area_checker.dart
@@ -7,6 +7,7 @@ import 'package:flutter/rendering.dart';
 
 import '../accessibility_issue.dart';
 import 'checker_base.dart';
+import 'ignore_minimum_tap_area_size.dart';
 
 /// Defines the minimum tap size per device type.
 class MinimumTapAreas {
@@ -165,28 +166,5 @@ Icon(
         nodePaintBounds.left < -delta ||
         nodePaintBounds.bottom > windowPhysicalSize.height + delta ||
         nodePaintBounds.right > windowPhysicalSize.width + delta;
-  }
-}
-
-class IgnoreMinimumTapAreaSize extends InheritedWidget {
-  const IgnoreMinimumTapAreaSize({
-    super.key,
-    required super.child,
-  });
-
-  static IgnoreMinimumTapAreaSize? maybeOf(BuildContext context) {
-    return LookupBoundary.dependOnInheritedWidgetOfExactType<IgnoreMinimumTapAreaSize>(context);
-  }
-
-  static IgnoreMinimumTapAreaSize of(BuildContext context) {
-    final IgnoreMinimumTapAreaSize? result =
-        context.dependOnInheritedWidgetOfExactType<IgnoreMinimumTapAreaSize>();
-    assert(result != null, 'No IgnoreMinimumTapAreaSize found in context');
-    return result!;
-  }
-
-  @override
-  bool updateShouldNotify(IgnoreMinimumTapAreaSize oldWidget) {
-    return false;
   }
 }

--- a/test/ignore_minimum_tap_area_size_test.dart
+++ b/test/ignore_minimum_tap_area_size_test.dart
@@ -1,0 +1,76 @@
+import 'package:accessibility_tools/accessibility_tools.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  setUp(() {
+    AccessibilityTools.debugRunCheckersInTests = true;
+  });
+
+  testWidgets(
+    'of returns parent IgnoreMinimumTapAreaSize',
+    (WidgetTester tester) async {
+      final childKey = GlobalKey();
+      await tester.pumpWidget(
+        TestApp(
+          child: IgnoreMinimumTapAreaSize(
+            child: Placeholder(key: childKey),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(() => IgnoreMinimumTapAreaSize.of(childKey.currentContext!),
+          returnsNormally);
+    },
+  );
+
+  testWidgets(
+    'maybe of returns parent IgnoreMinimumTapAreaSize if present',
+    (WidgetTester tester) async {
+      final childKey = GlobalKey();
+      await tester.pumpWidget(
+        TestApp(
+          child: IgnoreMinimumTapAreaSize(
+            child: Placeholder(key: childKey),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(IgnoreMinimumTapAreaSize.maybeOf(childKey.currentContext!),
+          isNotNull);
+    },
+  );
+
+  testWidgets(
+    'maybe of returns null if there is no IgnoreMinimumTapAreaSize parent',
+    (WidgetTester tester) async {
+      final childKey = GlobalKey();
+      await tester.pumpWidget(
+        TestApp(
+          child: Placeholder(key: childKey),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(
+          IgnoreMinimumTapAreaSize.maybeOf(childKey.currentContext!), isNull);
+    },
+  );
+
+  test(
+    'updateShouldNotify returns false',
+    () {
+      const widget1 = IgnoreMinimumTapAreaSize(child: Placeholder());
+      const widget2 = IgnoreMinimumTapAreaSize(child: Text(''));
+
+      expect(widget1.updateShouldNotify(widget2), isFalse);
+    },
+  );
+}

--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -1,5 +1,4 @@
 import 'package:accessibility_tools/accessibility_tools.dart';
-import 'package:accessibility_tools/src/checkers/ignore_minimum_tap_area_size.dart';
 import 'package:accessibility_tools/src/checkers/minimum_tap_area_checker.dart';
 import 'package:accessibility_tools/src/floating_action_buttons.dart';
 import 'package:flutter/foundation.dart';

--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -389,7 +389,7 @@ Icon(
 
   testWidgets(
     "Doesn't show warning if explicitly ignored by user",
-        (WidgetTester tester) async {
+    (WidgetTester tester) async {
       await tester.pumpWidget(
         TestApp(
           child: IgnoreMinimumTapAreaSize(

--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -1,4 +1,5 @@
 import 'package:accessibility_tools/accessibility_tools.dart';
+import 'package:accessibility_tools/src/checkers/ignore_minimum_tap_area_size.dart';
 import 'package:accessibility_tools/src/checkers/minimum_tap_area_checker.dart';
 import 'package:accessibility_tools/src/floating_action_buttons.dart';
 import 'package:flutter/foundation.dart';

--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -385,4 +385,29 @@ Icon(
       expect(format(100 / 6 /* 16.6(6) */), '16.67');
     },
   );
+
+  testWidgets(
+    "Doesn't show warning if explicitly ignored by user",
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          child: IgnoreMinimumTapAreaSize(
+            child: SizedBox(
+              width: 10,
+              height: 10,
+              child: GestureDetector(
+                child: const Text('Tap area'),
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AccessibilityIssuesToggle), findsNothing);
+      expect(find.byType(AccessibilityToolsToggle), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
Added widget IgnoreMinimumTapAreaSize to skip MinimumTapAreaChecker

Should fix #47 