### PR TITLE
Fix internal issues reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+* Fix: accessibility_tools no longer report their own internal issues
+
 ## 2.4.0
 
 * Add IgnoreMinimumTapAreaSize widget for ignoring tap area size checks

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ ignored by wrapping the corresponding widget with `IgnoreMinimumTapAreaSize`.
 
 Experimental: ensures that no flex widgets, such as `Column` and `Row`, overflow when a user is using larger font sizes. This checker is experimental, and disabled by default, and can be enabled via `AccessibilityTools(checkFontOverflows: true)`.
 
+This checker temporarily adjusts the text scale to simulate the effect of larger font sizes. When the check is performed, you might observe a visual increase in text size as part of this simulation (most noticeable after hot reload).
+
 ### Input label checker
 
 Makes sure text fields (`TextField`, `TextFormField`, `Autocomplete` etc) and inputs (`Checkbox`, `Radio`, `Switch` etc) have semantic labels.

--- a/lib/src/accessibility_tools.dart
+++ b/lib/src/accessibility_tools.dart
@@ -10,6 +10,7 @@ import 'accessibility_issue.dart';
 import 'checker_manager.dart';
 import 'checkers/checker_base.dart';
 import 'checkers/flex_overflow_checker.dart';
+import 'checkers/ignore_minimum_tap_area_size.dart';
 import 'checkers/image_label_checker.dart';
 import 'checkers/input_label_checker.dart';
 import 'checkers/minimum_tap_area_checker.dart';
@@ -60,6 +61,19 @@ class AccessibilityTools extends StatefulWidget {
   /// Forces accessibility checkers to run when running from a test.
   @visibleForTesting
   static bool debugRunCheckersInTests = false;
+
+  /// Forces accessibility tools to ignore its own tap area size issues.
+  ///
+  /// Accessibility tools uses Material widgets and is tested not to have
+  /// accessibility issues. However, in some rare cases issues can be
+  /// reported. For example, when [minimumTapAreas] is set to be bigger than
+  /// Material guidelines or when scrolling and widget is partially off screen.
+  ///
+  /// Setting this flag to true will ignore all accessibility issues in
+  /// accessibility tools. Setting this flag to false will report all
+  /// accessibility issues found in accessibility tools.
+  @visibleForTesting
+  static bool debugIgnoreTapAreaIssuesInTools = true;
 
   final Widget? child;
   final MinimumTapAreas? minimumTapAreas;
@@ -179,7 +193,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
           initialEntries: [
             OverlayEntry(
               builder: (_) {
-                return CheckerOverlay(
+                final child = CheckerOverlay(
                   checker: _checker,
                   buttonsAlignment: widget.buttonsAlignment,
                   enableButtonsDrag: widget.enableButtonsDrag,
@@ -194,6 +208,10 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
                     setState(() => _testingToolsVisible = false);
                   },
                 );
+
+                return AccessibilityTools.debugIgnoreTapAreaIssuesInTools
+                    ? IgnoreMinimumTapAreaSize(child: child)
+                    : child;
               },
             ),
             if (widget.testingToolsConfiguration.enabled)
@@ -201,7 +219,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
                 builder: (context) {
                   if (!_testingToolsVisible) return const SizedBox();
 
-                  return TestingToolsPanel(
+                  final child = TestingToolsPanel(
                     environment: _environment,
                     configuration: widget.testingToolsConfiguration,
                     onClose: () {
@@ -211,6 +229,10 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
                       setState(() => _environment = environment);
                     },
                   );
+
+                  return AccessibilityTools.debugIgnoreTapAreaIssuesInTools
+                      ? IgnoreMinimumTapAreaSize(child: child)
+                      : child;
                 },
               ),
           ],

--- a/lib/src/testing_tools/testing_tools_panel.dart
+++ b/lib/src/testing_tools/testing_tools_panel.dart
@@ -61,163 +61,158 @@ class _TestingToolsPanelState extends State<TestingToolsPanel> {
         : mediaQuery.textScaler;
     const gap = SizedBox(height: 18);
 
-    return Stack(
-      children: [
-        Material(
-          color: Theme.of(context).scaffoldBackgroundColor,
-          child: Padding(
-            padding: MediaQuery.paddingOf(context),
-            child: Column(
-              children: [
-                Toolbar(
-                  onClose: widget.onClose,
-                  onResetAll: () => widget.onEnvironmentUpdate(
-                    const TestEnvironment(),
-                  ),
-                ),
-                Expanded(
-                  child: ListView(
-                    padding: const EdgeInsets.all(16),
-                    children: [
-                      SliderTile(
-                        label:
-                            '''Text scale: ${textScaleFactor.scale(1.0).toStringAsFixed(1)}''',
-                        info:
-                            '''Change text scaler value to see how layouts behave with different font sizes''',
-                        value: textScaleFactor.scale(1.0),
-                        min: widget.configuration.minTextScale,
-                        max: widget.configuration.maxTextScale,
-                        onChanged: (value) {
-                          this.textScaleFactor = value;
-                          _notifyTestEnvironmentChanged();
-                        },
-                      ),
-                      gap,
-                      if (supportedLocales.isNotEmpty) ...[
-                        MultiValueToggle<Locale>(
-                          title: 'Localization',
-                          info:
-                              '''Force a specific locale found in WidgetsApp''',
-                          value: localeOverride,
-                          onTap: (value) {
-                            localeOverride = value;
-                            _notifyTestEnvironmentChanged();
-                          },
-                          values: supportedLocales.toList(),
-                          nameBuilder: (locale) {
-                            return locale?.toString() ?? 'System';
-                          },
-                        ),
-                      ],
-                      gap,
-                      MultiValueToggle<TextDirection>(
-                        value: textDirection,
-                        info: '''Force a specific text direction''',
-                        onTap: (value) {
-                          textDirection = value;
-                          _notifyTestEnvironmentChanged();
-                        },
-                        title: 'Text direction',
-                        values: TextDirection.values.toList(),
-                        nameBuilder: (value) =>
-                            value?.name.toUpperCase() ?? 'System',
-                      ),
-                      gap,
-                      MultiValueToggle(
-                        value: targetPlatform,
-                        info:
-                            '''Force a specific target platform. This usually changes scrolling behavior, toolbar back button icon, gesture navigation etc''',
-                        onTap: (value) {
-                          targetPlatform = value;
-                          _notifyTestEnvironmentChanged();
-                        },
-                        title: 'Platform',
-                        values: TargetPlatform.values,
-                        nameBuilder: (e) => e?.name ?? 'System',
-                      ),
-                      gap,
-                      MultiValueToggle<VisualDensity>(
-                        title: 'Density',
-                        info:
-                            '''Force a specific visual density supported by Flutter. This may change paddings, margins and icons sizes''',
-                        value: visualDensity,
-                        onTap: (value) {
-                          visualDensity = value;
-                          _notifyTestEnvironmentChanged();
-                        },
-                        values: const [
-                          VisualDensity.standard,
-                          VisualDensity.comfortable,
-                          VisualDensity.compact,
-                        ],
-                        nameBuilder: (e) {
-                          if (e == VisualDensity.standard) {
-                            return 'standard';
-                          } else if (e == VisualDensity.comfortable) {
-                            return 'comfortable';
-                          } else if (e == VisualDensity.compact) {
-                            return 'compact';
-                          } else {
-                            return 'System';
-                          }
-                        },
-                      ),
-                      gap,
-                      MultiValueToggle<bool?>(
-                        value: boldText,
-                        title: 'Bold text',
-                        info:
-                            '''Mimic platform's request to draw texts with a bold font weight''',
-                        onTap: (value) {
-                          boldText = value;
-                          _notifyTestEnvironmentChanged();
-                        },
-                        values: _onOffSystemValues,
-                        nameBuilder: _onOffSystemLabels,
-                      ),
-                      gap,
-                      MultiValueToggle<ColorModeSimulation?>(
-                        title: 'Color mode simulation',
-                        info:
-                            '''Simulate a certain color mode to check contrast and colors accessibility''',
-                        value: colorModeSimulation,
-                        onTap: (value) {
-                          colorModeSimulation = value;
-                          _notifyTestEnvironmentChanged();
-                        },
-                        values: ColorModeSimulation.values,
-                        nameBuilder: (e) => e?.name ?? 'Off',
-                      ),
-                      gap,
-                      SwitchToggle(
-                        title: 'Screen reader mode',
-                        info:
-                            '''Use Semantics Debugger to simulate how the app behaves with screen readers''',
-                        value: semanticsDebuggerEnabled ?? false,
-                        onChanged: (value) {
-                          semanticsDebuggerEnabled = value;
-                          _notifyTestEnvironmentChanged();
-                        },
-                      ),
-                      const SizedBox(height: 8),
-                      const Divider(),
-                      const SizedBox(height: 12),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: ElevatedButton.icon(
-                          onPressed: widget.onClose,
-                          icon: const Icon(Icons.close),
-                          label: const Text('Close'),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+    return Material(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: Padding(
+        padding: MediaQuery.paddingOf(context),
+        child: Column(
+          children: [
+            Toolbar(
+              onClose: widget.onClose,
+              onResetAll: () => widget.onEnvironmentUpdate(
+                const TestEnvironment(),
+              ),
             ),
-          ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  SliderTile(
+                    label:
+                        '''Text scale: ${textScaleFactor.scale(1.0).toStringAsFixed(1)}''',
+                    info:
+                        '''Change text scaler value to see how layouts behave with different font sizes''',
+                    value: textScaleFactor.scale(1.0),
+                    min: widget.configuration.minTextScale,
+                    max: widget.configuration.maxTextScale,
+                    onChanged: (value) {
+                      this.textScaleFactor = value;
+                      _notifyTestEnvironmentChanged();
+                    },
+                  ),
+                  gap,
+                  if (supportedLocales.isNotEmpty) ...[
+                    MultiValueToggle<Locale>(
+                      title: 'Localization',
+                      info: '''Force a specific locale found in WidgetsApp''',
+                      value: localeOverride,
+                      onTap: (value) {
+                        localeOverride = value;
+                        _notifyTestEnvironmentChanged();
+                      },
+                      values: supportedLocales.toList(),
+                      nameBuilder: (locale) {
+                        return locale?.toString() ?? 'System';
+                      },
+                    ),
+                  ],
+                  gap,
+                  MultiValueToggle<TextDirection>(
+                    value: textDirection,
+                    info: '''Force a specific text direction''',
+                    onTap: (value) {
+                      textDirection = value;
+                      _notifyTestEnvironmentChanged();
+                    },
+                    title: 'Text direction',
+                    values: TextDirection.values.toList(),
+                    nameBuilder: (value) =>
+                        value?.name.toUpperCase() ?? 'System',
+                  ),
+                  gap,
+                  MultiValueToggle(
+                    value: targetPlatform,
+                    info:
+                        '''Force a specific target platform. This usually changes scrolling behavior, toolbar back button icon, gesture navigation etc''',
+                    onTap: (value) {
+                      targetPlatform = value;
+                      _notifyTestEnvironmentChanged();
+                    },
+                    title: 'Platform',
+                    values: TargetPlatform.values,
+                    nameBuilder: (e) => e?.name ?? 'System',
+                  ),
+                  gap,
+                  MultiValueToggle<VisualDensity>(
+                    title: 'Density',
+                    info:
+                        '''Force a specific visual density supported by Flutter. This may change paddings, margins and icons sizes''',
+                    value: visualDensity,
+                    onTap: (value) {
+                      visualDensity = value;
+                      _notifyTestEnvironmentChanged();
+                    },
+                    values: const [
+                      VisualDensity.standard,
+                      VisualDensity.comfortable,
+                      VisualDensity.compact,
+                    ],
+                    nameBuilder: (e) {
+                      if (e == VisualDensity.standard) {
+                        return 'standard';
+                      } else if (e == VisualDensity.comfortable) {
+                        return 'comfortable';
+                      } else if (e == VisualDensity.compact) {
+                        return 'compact';
+                      } else {
+                        return 'System';
+                      }
+                    },
+                  ),
+                  gap,
+                  MultiValueToggle<bool?>(
+                    value: boldText,
+                    title: 'Bold text',
+                    info:
+                        '''Mimic platform's request to draw texts with a bold font weight''',
+                    onTap: (value) {
+                      boldText = value;
+                      _notifyTestEnvironmentChanged();
+                    },
+                    values: _onOffSystemValues,
+                    nameBuilder: _onOffSystemLabels,
+                  ),
+                  gap,
+                  MultiValueToggle<ColorModeSimulation?>(
+                    title: 'Color mode simulation',
+                    info:
+                        '''Simulate a certain color mode to check contrast and colors accessibility''',
+                    value: colorModeSimulation,
+                    onTap: (value) {
+                      colorModeSimulation = value;
+                      _notifyTestEnvironmentChanged();
+                    },
+                    values: ColorModeSimulation.values,
+                    nameBuilder: (e) => e?.name ?? 'Off',
+                  ),
+                  gap,
+                  SwitchToggle(
+                    title: 'Screen reader mode',
+                    info:
+                        '''Use Semantics Debugger to simulate how the app behaves with screen readers''',
+                    value: semanticsDebuggerEnabled ?? false,
+                    onChanged: (value) {
+                      semanticsDebuggerEnabled = value;
+                      _notifyTestEnvironmentChanged();
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  const Divider(),
+                  const SizedBox(height: 12),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: ElevatedButton.icon(
+                      onPressed: widget.onClose,
+                      icon: const Icon(Icons.close),
+                      label: const Text('Close'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: accessibility_tools
 description: Checkers and tools to ensure your app is accessible to all. Ensures your app is accessible from day one, by checking your interface as you build it.
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/rebelappstudio/accessibility_tools/
 topics:
   - accessibility

--- a/test/accessibility_testing_tools_test.dart
+++ b/test/accessibility_testing_tools_test.dart
@@ -15,6 +15,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(

--- a/test/checker_widget_test.dart
+++ b/test/checker_widget_test.dart
@@ -7,6 +7,7 @@ void main() {
     "Builder doesn't prevent root widget changing",
     (WidgetTester tester) async {
       AccessibilityTools.debugRunCheckersInTests = true;
+      AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
 
       await tester.pumpWidget(
         MaterialApp(

--- a/test/disabled_in_tests_test.dart
+++ b/test/disabled_in_tests_test.dart
@@ -1,4 +1,5 @@
-import 'package:accessibility_tools/src/accessibility_tools.dart';
+import 'package:accessibility_tools/accessibility_tools.dart';
+import 'package:accessibility_tools/src/floating_action_buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -31,6 +32,85 @@ void main() {
 
       // Verify button is rendered
       expect(find.byType(SizedBox), findsOneWidget);
+    },
+  );
+
+  test(
+    'debugIgnoreTapAreaIssuesInTools set to true by default and can be changed',
+    () {
+      // Verify default value
+      expect(AccessibilityTools.debugIgnoreTapAreaIssuesInTools, isTrue);
+
+      AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
+      expect(AccessibilityTools.debugIgnoreTapAreaIssuesInTools, isFalse);
+    },
+  );
+
+  testWidgets(
+    '''Ignores own tap area size issues when debugIgnoreTapAreaIssuesInTools set to true''',
+    (tester) async {
+      AccessibilityTools.debugRunCheckersInTests = true;
+      AccessibilityTools.debugIgnoreTapAreaIssuesInTools = true;
+
+      final log = await recordDebugPrint(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            builder: (context, child) => AccessibilityTools(
+              minimumTapAreas: const MinimumTapAreas(mobile: 100, desktop: 100),
+              logLevel: LogLevel.warning,
+              child: child,
+            ),
+            home: const SizedBox(),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(find.byType(AccessibilityIssuesToggle), findsNothing);
+
+        await tester.tap(find.byType(AccessibilityToolsToggle));
+        await tester.pumpAndSettle();
+      });
+
+      expect(log, isEmpty);
+    },
+  );
+
+  testWidgets(
+    '''Does not ignore own tap area size issues when debugIgnoreTapAreaIssuesInTools set to false''',
+    (tester) async {
+      AccessibilityTools.debugRunCheckersInTests = true;
+      AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
+
+      final log = await recordDebugPrint(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            builder: (context, child) => AccessibilityTools(
+              minimumTapAreas: const MinimumTapAreas(mobile: 100, desktop: 100),
+              logLevel: LogLevel.warning,
+              child: child,
+            ),
+            home: const SizedBox(),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(find.byType(AccessibilityIssuesToggle), findsOneWidget);
+
+        await tester.tap(find.byType(AccessibilityToolsToggle));
+        await tester.pumpAndSettle();
+      });
+
+      // Issue caused by Accessibility tools' buttons being too small
+      expect(
+        log,
+        contains('Accessibility issue 1: Tap area of 48x48 is too small'),
+      );
+
+      // Issue caused by the testing tools panel buttons being too small
+      expect(
+        log,
+        contains('Accessibility issue 24: Tap area of'),
+      );
     },
   );
 }

--- a/test/flex_overflow_checker_test.dart
+++ b/test/flex_overflow_checker_test.dart
@@ -7,6 +7,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(

--- a/test/ignore_minimum_tap_area_size_test.dart
+++ b/test/ignore_minimum_tap_area_size_test.dart
@@ -7,6 +7,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(

--- a/test/input_label_checker_test.dart
+++ b/test/input_label_checker_test.dart
@@ -8,6 +8,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(

--- a/test/log_level_test.dart
+++ b/test/log_level_test.dart
@@ -7,6 +7,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets('Can print all available logs', (tester) async {

--- a/test/minimum_tap_area_checker_test.dart
+++ b/test/minimum_tap_area_checker_test.dart
@@ -10,6 +10,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(

--- a/test/multiple_checkers_test.dart
+++ b/test/multiple_checkers_test.dart
@@ -7,6 +7,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(

--- a/test/semantic_label_checker_test.dart
+++ b/test/semantic_label_checker_test.dart
@@ -8,6 +8,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(

--- a/test/testing_tools_configuration_test.dart
+++ b/test/testing_tools_configuration_test.dart
@@ -10,6 +10,7 @@ import 'test_utils.dart';
 void main() {
   setUp(() {
     AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
   testWidgets(


### PR DESCRIPTION
This PR disables reporting of the accessibility tools' own internal issues. Accessibility tools use Material widgets and are tested to be accessible. This PR gets rid of false positive tap area reports in certain cases.

Related: #71 #72 