### PR TITLE
feat: add AccessibilityTools in Release mode

### DIFF
--- a/lib/src/accessibility_tools.dart
+++ b/lib/src/accessibility_tools.dart
@@ -172,8 +172,13 @@ class AccessibilityTools extends StatefulWidget {
   State<AccessibilityTools> createState() => _AccessibilityToolsState();
 }
 
-class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUpdateMixin {
-  late CheckerManager _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableInReleaseMode);
+class _AccessibilityToolsState extends State<AccessibilityTools>
+    with SemanticUpdateMixin {
+  late CheckerManager _checker = CheckerManager(
+    checkers: _getCheckers(),
+    logLevel: widget.logLevel,
+    debugLogsEnabled: !kReleaseMode || !widget.enableInReleaseMode,
+  );
 
   bool _testingToolsVisible = false;
   late TestEnvironment _environment = widget.testEnvironment;
@@ -199,7 +204,11 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
   @override
   void didUpdateWidget(covariant AccessibilityTools oldWidget) {
     _checker.dispose();
-    _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableInReleaseMode);
+    _checker = CheckerManager(
+      checkers: _getCheckers(),
+      logLevel: widget.logLevel,
+      debugLogsEnabled: !kReleaseMode || !widget.enableInReleaseMode,
+    );
     super.didUpdateWidget(oldWidget);
   }
 
@@ -209,8 +218,12 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
 
     return [
       if (widget.checkSemanticLabels) SemanticLabelChecker(),
-      if (minTapAreas != null) MinimumTapAreaChecker(minTapArea: minTapAreas.forPlatform(targetPlatform)),
-      if (widget.checkFontOverflows) FlexOverflowChecker(textScaleFactor: _iOSLargestTextScaleFactor),
+      if (minTapAreas != null)
+        MinimumTapAreaChecker(
+          minTapArea: minTapAreas.forPlatform(targetPlatform),
+        ),
+      if (widget.checkFontOverflows)
+        FlexOverflowChecker(textScaleFactor: _iOSLargestTextScaleFactor),
       if (widget.checkMissingInputLabels) InputLabelChecker(),
       if (widget.checkImageLabels) ImageLabelChecker(),
     ];
@@ -224,12 +237,18 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
   /// should not be used.
   bool get _isTest {
     final bindingName = WidgetsBinding.instance.runtimeType.toString();
-    return const ['AutomatedTestWidgetsFlutterBinding', 'LiveTestWidgetsFlutterBinding', 'TestWidgetsFlutterBinding'].contains(bindingName);
+    return const [
+      'AutomatedTestWidgetsFlutterBinding',
+      'LiveTestWidgetsFlutterBinding',
+      'TestWidgetsFlutterBinding',
+    ].contains(bindingName);
   }
 
   @override
   Widget build(BuildContext context) {
-    final shouldDisableAccessibilityTools = (kReleaseMode && !widget.enableInReleaseMode) || (!AccessibilityTools.debugRunCheckersInTests && _isTest);
+    final shouldDisableAccessibilityTools =
+        (kReleaseMode && !widget.enableInReleaseMode) ||
+        (!AccessibilityTools.debugRunCheckersInTests && _isTest);
 
     if (shouldDisableAccessibilityTools) {
       return widget.child!;
@@ -259,7 +278,8 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
                   checker: _checker,
                   buttonsAlignment: widget.buttonsAlignment,
                   enableButtonsDrag: widget.enableButtonsDrag,
-                  isTestingPanelEnabled: widget.testingToolsConfiguration.enabled,
+                  isTestingPanelEnabled:
+                      widget.testingToolsConfiguration.enabled,
                   onToolsButtonPressed: () {
                     setState(() {
                       _testingToolsVisible = !_testingToolsVisible;
@@ -270,7 +290,9 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
                   },
                 );
 
-                return AccessibilityTools.debugIgnoreTapAreaIssuesInTools ? IgnoreMinimumTapAreaSize(child: child) : child;
+                return AccessibilityTools.debugIgnoreTapAreaIssuesInTools
+                    ? IgnoreMinimumTapAreaSize(child: child)
+                    : child;
               },
             ),
             if (widget.testingToolsConfiguration.enabled)
@@ -292,7 +314,9 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
                     },
                   );
 
-                  return AccessibilityTools.debugIgnoreTapAreaIssuesInTools ? IgnoreMinimumTapAreaSize(child: child) : child;
+                  return AccessibilityTools.debugIgnoreTapAreaIssuesInTools
+                      ? IgnoreMinimumTapAreaSize(child: child)
+                      : child;
                 },
               ),
           ],
@@ -357,7 +381,11 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
 
   static Rect _inflateToMinimumSize(Rect rect) {
     if (rect.shortestSide < _warningBoxMinSize) {
-      return Rect.fromCenter(center: rect.center, width: max(_warningBoxMinSize, rect.width), height: max(_warningBoxMinSize, rect.height));
+      return Rect.fromCenter(
+        center: rect.center,
+        width: max(_warningBoxMinSize, rect.width),
+        height: max(_warningBoxMinSize, rect.height),
+      );
     }
 
     return rect;
@@ -369,7 +397,9 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
       animation: widget.checker,
       builder: (context, _) {
         final issues = List<AccessibilityIssue>.of(widget.checker.issues);
-        final rects = issues.where((element) => element.renderObject.attached).groupListsBy((issue) => issue.renderObject.getGlobalRect());
+        final rects = issues
+            .where((element) => element.renderObject.attached)
+            .groupListsBy((issue) => issue.renderObject.getGlobalRect());
 
         const errorBorderWidth = 5.0;
 
@@ -378,8 +408,17 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
             if (showOverlays)
               for (final entry in rects.entries)
                 Positioned.fromRect(
-                  rect: _inflateToMinimumSize(entry.key).inflate(errorBorderWidth),
-                  child: WarningBox(borderWidth: errorBorderWidth, message: entry.value.map((e) => e.message).join('\n\n'), size: Size(max(5, entry.key.width) + errorBorderWidth, max(5, entry.key.height) + errorBorderWidth)),
+                  rect: _inflateToMinimumSize(
+                    entry.key,
+                  ).inflate(errorBorderWidth),
+                  child: WarningBox(
+                    borderWidth: errorBorderWidth,
+                    message: entry.value.map((e) => e.message).join('\n\n'),
+                    size: Size(
+                      max(5, entry.key.width) + errorBorderWidth,
+                      max(5, entry.key.height) + errorBorderWidth,
+                    ),
+                  ),
                 ),
             _DraggablePositioned(
               minSpacing: 10,
@@ -411,7 +450,12 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
 }
 
 class _DraggablePositioned extends StatefulWidget {
-  const _DraggablePositioned({this.initialAlignment = ButtonsAlignment.bottomRight, required this.minSpacing, required this.enableDrag, required this.child});
+  const _DraggablePositioned({
+    this.initialAlignment = ButtonsAlignment.bottomRight,
+    required this.minSpacing,
+    required this.enableDrag,
+    required this.child,
+  });
 
   final ButtonsAlignment initialAlignment;
   final double minSpacing;
@@ -478,7 +522,8 @@ class _DraggablePositionedState extends State<_DraggablePositioned> {
     }
   }
 
-  void _onPanStart(DragStartDetails details) => _panPosition = details.globalPosition;
+  void _onPanStart(DragStartDetails details) =>
+      _panPosition = details.globalPosition;
 
   void _onPanUpdate(DragUpdateDetails details) {
     if (_isDragging) {
@@ -512,14 +557,27 @@ class _DraggablePositionedState extends State<_DraggablePositioned> {
     return _buildAlignedPosition(
       context,
       SafeArea(
-        child: widget.enableDrag ? GestureDetector(onPanStart: _onPanStart, onPanUpdate: _onPanUpdate, onPanEnd: _onPanEnd, child: widget.child) : widget.child,
+        child: widget.enableDrag
+            ? GestureDetector(
+                onPanStart: _onPanStart,
+                onPanUpdate: _onPanUpdate,
+                onPanEnd: _onPanEnd,
+                child: widget.child,
+              )
+            : widget.child,
       ),
     );
   }
 }
 
 class _WarningButton extends StatelessWidget {
-  const _WarningButton({required this.issues, required this.onPressed, required this.onToolsButtonPressed, required this.toggled, required this.isTestingPanelEnabled});
+  const _WarningButton({
+    required this.issues,
+    required this.onPressed,
+    required this.onToolsButtonPressed,
+    required this.toggled,
+    required this.isTestingPanelEnabled,
+  });
 
   final bool toggled;
   final bool isTestingPanelEnabled;
@@ -532,8 +590,16 @@ class _WarningButton extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (issues.isNotEmpty) AccessibilityIssuesToggle(toggled: toggled, issues: issues, onPressed: onPressed),
-        if (isTestingPanelEnabled) ...[const SizedBox(height: 12), AccessibilityToolsToggle(onToolsButtonPressed: onToolsButtonPressed)],
+        if (issues.isNotEmpty)
+          AccessibilityIssuesToggle(
+            toggled: toggled,
+            issues: issues,
+            onPressed: onPressed,
+          ),
+        if (isTestingPanelEnabled) ...[
+          const SizedBox(height: 12),
+          AccessibilityToolsToggle(onToolsButtonPressed: onToolsButtonPressed),
+        ],
       ],
     );
   }
@@ -543,7 +609,12 @@ class _WarningButton extends StatelessWidget {
 @visibleForTesting
 class WarningBox extends StatelessWidget {
   /// Default constructor.
-  const WarningBox({super.key, required this.size, required this.borderWidth, required this.message});
+  const WarningBox({
+    super.key,
+    required this.size,
+    required this.borderWidth,
+    required this.message,
+  });
 
   /// Size of the warning box.
   final Size size;
@@ -562,7 +633,10 @@ class WarningBox extends StatelessWidget {
       child: Tooltip(
         padding: const EdgeInsets.all(10),
         message: message,
-        decoration: const BoxDecoration(color: Colors.blue, borderRadius: BorderRadius.all(Radius.circular(8))),
+        decoration: const BoxDecoration(
+          color: Colors.blue,
+          borderRadius: BorderRadius.all(Radius.circular(8)),
+        ),
         textStyle: const TextStyle(fontSize: 15, color: Colors.white),
         child: Center(
           child: CustomPaint(
@@ -591,12 +665,21 @@ class WarningBoxPainter extends CustomPainter {
 
   static final Paint _indicatorPaint = Paint()
     ..style = PaintingStyle.stroke
-    ..shader = ui.Gradient.linear(Offset.zero, const Offset(10.0, 10.0), <Color>[_black, _yellow, _yellow, _black], <double>[0.25, 0.25, 0.75, 0.75], TileMode.repeated)
+    ..shader = ui.Gradient.linear(
+      Offset.zero,
+      const Offset(10.0, 10.0),
+      <Color>[_black, _yellow, _yellow, _black],
+      <double>[0.25, 0.25, 0.75, 0.75],
+      TileMode.repeated,
+    )
     ..strokeWidth = 5.0;
 
   @override
   void paint(Canvas canvas, Size size) {
-    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), _indicatorPaint);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      _indicatorPaint,
+    );
   }
 
   @override

--- a/lib/src/accessibility_tools.dart
+++ b/lib/src/accessibility_tools.dart
@@ -67,7 +67,7 @@ class AccessibilityTools extends StatefulWidget {
     this.enableButtonsDrag = true,
     this.testingToolsConfiguration = const TestingToolsConfiguration(),
     this.testEnvironment = const TestEnvironment(),
-    this.enableAccessibilityControlsOnReleaseMode = false,
+    this.enableInReleaseMode = false,
   });
 
   /// Forces accessibility checkers to run when running from a test.
@@ -166,14 +166,14 @@ class AccessibilityTools extends StatefulWidget {
   /// This is useful for testing accessibility in release mode,
   /// but should be used with caution as it may have performance implications.
   /// False by default.
-  final bool enableAccessibilityControlsOnReleaseMode;
+  final bool enableInReleaseMode;
 
   @override
   State<AccessibilityTools> createState() => _AccessibilityToolsState();
 }
 
 class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUpdateMixin {
-  late CheckerManager _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableAccessibilityControlsOnReleaseMode);
+  late CheckerManager _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableInReleaseMode);
 
   bool _testingToolsVisible = false;
   late TestEnvironment _environment = widget.testEnvironment;
@@ -199,7 +199,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
   @override
   void didUpdateWidget(covariant AccessibilityTools oldWidget) {
     _checker.dispose();
-    _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableAccessibilityControlsOnReleaseMode);
+    _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableInReleaseMode);
     super.didUpdateWidget(oldWidget);
   }
 
@@ -229,7 +229,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUp
 
   @override
   Widget build(BuildContext context) {
-    final shouldDisableAccessibilityTools = (kReleaseMode && !widget.enableAccessibilityControlsOnReleaseMode) || (!AccessibilityTools.debugRunCheckersInTests && _isTest);
+    final shouldDisableAccessibilityTools = (kReleaseMode && !widget.enableInReleaseMode) || (!AccessibilityTools.debugRunCheckersInTests && _isTest);
 
     if (shouldDisableAccessibilityTools) {
       return widget.child!;

--- a/lib/src/accessibility_tools.dart
+++ b/lib/src/accessibility_tools.dart
@@ -67,6 +67,7 @@ class AccessibilityTools extends StatefulWidget {
     this.enableButtonsDrag = true,
     this.testingToolsConfiguration = const TestingToolsConfiguration(),
     this.testEnvironment = const TestEnvironment(),
+    this.enableAccessibilityControlsOnReleaseMode = false,
   });
 
   /// Forces accessibility checkers to run when running from a test.
@@ -160,16 +161,19 @@ class AccessibilityTools extends StatefulWidget {
   /// Default test environment for the testing tools.
   final TestEnvironment testEnvironment;
 
+  /// Whether to enable accessibility controls when running in release mode.
+  ///
+  /// This is useful for testing accessibility in release mode,
+  /// but should be used with caution as it may have performance implications.
+  /// False by default.
+  final bool enableAccessibilityControlsOnReleaseMode;
+
   @override
   State<AccessibilityTools> createState() => _AccessibilityToolsState();
 }
 
-class _AccessibilityToolsState extends State<AccessibilityTools>
-    with SemanticUpdateMixin {
-  late CheckerManager _checker = CheckerManager(
-    checkers: _getCheckers(),
-    logLevel: widget.logLevel,
-  );
+class _AccessibilityToolsState extends State<AccessibilityTools> with SemanticUpdateMixin {
+  late CheckerManager _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableAccessibilityControlsOnReleaseMode);
 
   bool _testingToolsVisible = false;
   late TestEnvironment _environment = widget.testEnvironment;
@@ -195,10 +199,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
   @override
   void didUpdateWidget(covariant AccessibilityTools oldWidget) {
     _checker.dispose();
-    _checker = CheckerManager(
-      checkers: _getCheckers(),
-      logLevel: widget.logLevel,
-    );
+    _checker = CheckerManager(checkers: _getCheckers(), logLevel: widget.logLevel, debugLogsEnabled: !kReleaseMode || !widget.enableAccessibilityControlsOnReleaseMode);
     super.didUpdateWidget(oldWidget);
   }
 
@@ -208,12 +209,8 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
 
     return [
       if (widget.checkSemanticLabels) SemanticLabelChecker(),
-      if (minTapAreas != null)
-        MinimumTapAreaChecker(
-          minTapArea: minTapAreas.forPlatform(targetPlatform),
-        ),
-      if (widget.checkFontOverflows)
-        FlexOverflowChecker(textScaleFactor: _iOSLargestTextScaleFactor),
+      if (minTapAreas != null) MinimumTapAreaChecker(minTapArea: minTapAreas.forPlatform(targetPlatform)),
+      if (widget.checkFontOverflows) FlexOverflowChecker(textScaleFactor: _iOSLargestTextScaleFactor),
       if (widget.checkMissingInputLabels) InputLabelChecker(),
       if (widget.checkImageLabels) ImageLabelChecker(),
     ];
@@ -227,17 +224,14 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
   /// should not be used.
   bool get _isTest {
     final bindingName = WidgetsBinding.instance.runtimeType.toString();
-    return const [
-      'AutomatedTestWidgetsFlutterBinding',
-      'LiveTestWidgetsFlutterBinding',
-      'TestWidgetsFlutterBinding',
-    ].contains(bindingName);
+    return const ['AutomatedTestWidgetsFlutterBinding', 'LiveTestWidgetsFlutterBinding', 'TestWidgetsFlutterBinding'].contains(bindingName);
   }
 
   @override
   Widget build(BuildContext context) {
-    if (kReleaseMode ||
-        (!AccessibilityTools.debugRunCheckersInTests && _isTest)) {
+    final shouldDisableAccessibilityTools = (kReleaseMode && !widget.enableAccessibilityControlsOnReleaseMode) || (!AccessibilityTools.debugRunCheckersInTests && _isTest);
+
+    if (shouldDisableAccessibilityTools) {
       return widget.child!;
     }
 
@@ -265,8 +259,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
                   checker: _checker,
                   buttonsAlignment: widget.buttonsAlignment,
                   enableButtonsDrag: widget.enableButtonsDrag,
-                  isTestingPanelEnabled:
-                      widget.testingToolsConfiguration.enabled,
+                  isTestingPanelEnabled: widget.testingToolsConfiguration.enabled,
                   onToolsButtonPressed: () {
                     setState(() {
                       _testingToolsVisible = !_testingToolsVisible;
@@ -277,9 +270,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
                   },
                 );
 
-                return AccessibilityTools.debugIgnoreTapAreaIssuesInTools
-                    ? IgnoreMinimumTapAreaSize(child: child)
-                    : child;
+                return AccessibilityTools.debugIgnoreTapAreaIssuesInTools ? IgnoreMinimumTapAreaSize(child: child) : child;
               },
             ),
             if (widget.testingToolsConfiguration.enabled)
@@ -301,9 +292,7 @@ class _AccessibilityToolsState extends State<AccessibilityTools>
                     },
                   );
 
-                  return AccessibilityTools.debugIgnoreTapAreaIssuesInTools
-                      ? IgnoreMinimumTapAreaSize(child: child)
-                      : child;
+                  return AccessibilityTools.debugIgnoreTapAreaIssuesInTools ? IgnoreMinimumTapAreaSize(child: child) : child;
                 },
               ),
           ],
@@ -368,11 +357,7 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
 
   static Rect _inflateToMinimumSize(Rect rect) {
     if (rect.shortestSide < _warningBoxMinSize) {
-      return Rect.fromCenter(
-        center: rect.center,
-        width: max(_warningBoxMinSize, rect.width),
-        height: max(_warningBoxMinSize, rect.height),
-      );
+      return Rect.fromCenter(center: rect.center, width: max(_warningBoxMinSize, rect.width), height: max(_warningBoxMinSize, rect.height));
     }
 
     return rect;
@@ -384,9 +369,7 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
       animation: widget.checker,
       builder: (context, _) {
         final issues = List<AccessibilityIssue>.of(widget.checker.issues);
-        final rects = issues
-            .where((element) => element.renderObject.attached)
-            .groupListsBy((issue) => issue.renderObject.getGlobalRect());
+        final rects = issues.where((element) => element.renderObject.attached).groupListsBy((issue) => issue.renderObject.getGlobalRect());
 
         const errorBorderWidth = 5.0;
 
@@ -395,17 +378,8 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
             if (showOverlays)
               for (final entry in rects.entries)
                 Positioned.fromRect(
-                  rect: _inflateToMinimumSize(
-                    entry.key,
-                  ).inflate(errorBorderWidth),
-                  child: WarningBox(
-                    borderWidth: errorBorderWidth,
-                    message: entry.value.map((e) => e.message).join('\n\n'),
-                    size: Size(
-                      max(5, entry.key.width) + errorBorderWidth,
-                      max(5, entry.key.height) + errorBorderWidth,
-                    ),
-                  ),
+                  rect: _inflateToMinimumSize(entry.key).inflate(errorBorderWidth),
+                  child: WarningBox(borderWidth: errorBorderWidth, message: entry.value.map((e) => e.message).join('\n\n'), size: Size(max(5, entry.key.width) + errorBorderWidth, max(5, entry.key.height) + errorBorderWidth)),
                 ),
             _DraggablePositioned(
               minSpacing: 10,
@@ -437,12 +411,7 @@ class _CheckerOverlayState extends State<CheckerOverlay> {
 }
 
 class _DraggablePositioned extends StatefulWidget {
-  const _DraggablePositioned({
-    this.initialAlignment = ButtonsAlignment.bottomRight,
-    required this.minSpacing,
-    required this.enableDrag,
-    required this.child,
-  });
+  const _DraggablePositioned({this.initialAlignment = ButtonsAlignment.bottomRight, required this.minSpacing, required this.enableDrag, required this.child});
 
   final ButtonsAlignment initialAlignment;
   final double minSpacing;
@@ -509,8 +478,7 @@ class _DraggablePositionedState extends State<_DraggablePositioned> {
     }
   }
 
-  void _onPanStart(DragStartDetails details) =>
-      _panPosition = details.globalPosition;
+  void _onPanStart(DragStartDetails details) => _panPosition = details.globalPosition;
 
   void _onPanUpdate(DragUpdateDetails details) {
     if (_isDragging) {
@@ -544,27 +512,14 @@ class _DraggablePositionedState extends State<_DraggablePositioned> {
     return _buildAlignedPosition(
       context,
       SafeArea(
-        child: widget.enableDrag
-            ? GestureDetector(
-                onPanStart: _onPanStart,
-                onPanUpdate: _onPanUpdate,
-                onPanEnd: _onPanEnd,
-                child: widget.child,
-              )
-            : widget.child,
+        child: widget.enableDrag ? GestureDetector(onPanStart: _onPanStart, onPanUpdate: _onPanUpdate, onPanEnd: _onPanEnd, child: widget.child) : widget.child,
       ),
     );
   }
 }
 
 class _WarningButton extends StatelessWidget {
-  const _WarningButton({
-    required this.issues,
-    required this.onPressed,
-    required this.onToolsButtonPressed,
-    required this.toggled,
-    required this.isTestingPanelEnabled,
-  });
+  const _WarningButton({required this.issues, required this.onPressed, required this.onToolsButtonPressed, required this.toggled, required this.isTestingPanelEnabled});
 
   final bool toggled;
   final bool isTestingPanelEnabled;
@@ -577,16 +532,8 @@ class _WarningButton extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (issues.isNotEmpty)
-          AccessibilityIssuesToggle(
-            toggled: toggled,
-            issues: issues,
-            onPressed: onPressed,
-          ),
-        if (isTestingPanelEnabled) ...[
-          const SizedBox(height: 12),
-          AccessibilityToolsToggle(onToolsButtonPressed: onToolsButtonPressed),
-        ],
+        if (issues.isNotEmpty) AccessibilityIssuesToggle(toggled: toggled, issues: issues, onPressed: onPressed),
+        if (isTestingPanelEnabled) ...[const SizedBox(height: 12), AccessibilityToolsToggle(onToolsButtonPressed: onToolsButtonPressed)],
       ],
     );
   }
@@ -596,12 +543,7 @@ class _WarningButton extends StatelessWidget {
 @visibleForTesting
 class WarningBox extends StatelessWidget {
   /// Default constructor.
-  const WarningBox({
-    super.key,
-    required this.size,
-    required this.borderWidth,
-    required this.message,
-  });
+  const WarningBox({super.key, required this.size, required this.borderWidth, required this.message});
 
   /// Size of the warning box.
   final Size size;
@@ -620,10 +562,7 @@ class WarningBox extends StatelessWidget {
       child: Tooltip(
         padding: const EdgeInsets.all(10),
         message: message,
-        decoration: const BoxDecoration(
-          color: Colors.blue,
-          borderRadius: BorderRadius.all(Radius.circular(8)),
-        ),
+        decoration: const BoxDecoration(color: Colors.blue, borderRadius: BorderRadius.all(Radius.circular(8))),
         textStyle: const TextStyle(fontSize: 15, color: Colors.white),
         child: Center(
           child: CustomPaint(
@@ -652,21 +591,12 @@ class WarningBoxPainter extends CustomPainter {
 
   static final Paint _indicatorPaint = Paint()
     ..style = PaintingStyle.stroke
-    ..shader = ui.Gradient.linear(
-      Offset.zero,
-      const Offset(10.0, 10.0),
-      <Color>[_black, _yellow, _yellow, _black],
-      <double>[0.25, 0.25, 0.75, 0.75],
-      TileMode.repeated,
-    )
+    ..shader = ui.Gradient.linear(Offset.zero, const Offset(10.0, 10.0), <Color>[_black, _yellow, _yellow, _black], <double>[0.25, 0.25, 0.75, 0.75], TileMode.repeated)
     ..strokeWidth = 5.0;
 
   @override
   void paint(Canvas canvas, Size size) {
-    canvas.drawRect(
-      Rect.fromLTWH(0, 0, size.width, size.height),
-      _indicatorPaint,
-    );
+    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), _indicatorPaint);
   }
 
   @override

--- a/lib/src/checker_manager.dart
+++ b/lib/src/checker_manager.dart
@@ -13,7 +13,11 @@ import 'enums/log_level.dart';
 /// changes.
 class CheckerManager extends ChangeNotifier {
   /// Default constructor.
-  CheckerManager({required this.checkers, required this.logLevel, this.debugLogsEnabled = true});
+  CheckerManager({
+    required this.checkers,
+    required this.logLevel,
+    this.debugLogsEnabled = true,
+  });
 
   /// A list of enabled checkers.
   final Iterable<CheckerBase> checkers;

--- a/lib/src/checker_manager.dart
+++ b/lib/src/checker_manager.dart
@@ -78,12 +78,16 @@ class CheckerManager extends ChangeNotifier {
       child.visitChildrenForSemantics(visitor);
     };
 
-    WidgetsBinding.instance.rootElement?.renderObject?.visitChildrenForSemantics(visitor);
+    WidgetsBinding.instance.rootElement?.renderObject
+        ?.visitChildrenForSemantics(visitor);
 
     return renderObjects;
   }
 
-  void _logAccessibilityIssues(LogLevel logLevel, List<AccessibilityIssue> issues) {
+  void _logAccessibilityIssues(
+    LogLevel logLevel,
+    List<AccessibilityIssue> issues,
+  ) {
     if (logLevel == LogLevel.none || !debugLogsEnabled) return;
 
     debugPrint('''
@@ -117,7 +121,9 @@ extension on DebugCreator {
   /// associated with, including the location in the source code the widget was
   /// created.
   String toWidgetCreatorString() {
-    final diagnosticsNodes = debugTransformDebugCreator([DiagnosticsDebugCreator(this)]);
+    final diagnosticsNodes = debugTransformDebugCreator([
+      DiagnosticsDebugCreator(this),
+    ]);
     return diagnosticsNodes.map((e) => e.toStringDeep()).join('\n');
   }
 }

--- a/lib/src/checker_manager.dart
+++ b/lib/src/checker_manager.dart
@@ -13,13 +13,20 @@ import 'enums/log_level.dart';
 /// changes.
 class CheckerManager extends ChangeNotifier {
   /// Default constructor.
-  CheckerManager({required this.checkers, required this.logLevel});
+  CheckerManager({required this.checkers, required this.logLevel, this.debugLogsEnabled = true});
 
   /// A list of enabled checkers.
   final Iterable<CheckerBase> checkers;
 
   /// Log level for the accessibility issues.
   final LogLevel logLevel;
+
+  /// Whether to enable debug logs for accessibility issues.
+  ///
+  /// When false, accessibility issues are still detected and displayed
+  /// in the UI, but no console logs are printed.
+  /// Useful when enabling accessibility controls in release mode.
+  final bool debugLogsEnabled;
 
   /// A list of current accessibility issues.
   List<AccessibilityIssue> get issues => _issues;
@@ -71,17 +78,13 @@ class CheckerManager extends ChangeNotifier {
       child.visitChildrenForSemantics(visitor);
     };
 
-    WidgetsBinding.instance.rootElement?.renderObject
-        ?.visitChildrenForSemantics(visitor);
+    WidgetsBinding.instance.rootElement?.renderObject?.visitChildrenForSemantics(visitor);
 
     return renderObjects;
   }
 
-  void _logAccessibilityIssues(
-    LogLevel logLevel,
-    List<AccessibilityIssue> issues,
-  ) {
-    if (logLevel == LogLevel.none) return;
+  void _logAccessibilityIssues(LogLevel logLevel, List<AccessibilityIssue> issues) {
+    if (logLevel == LogLevel.none || !debugLogsEnabled) return;
 
     debugPrint('''
 ==========================
@@ -114,9 +117,7 @@ extension on DebugCreator {
   /// associated with, including the location in the source code the widget was
   /// created.
   String toWidgetCreatorString() {
-    final diagnosticsNodes = debugTransformDebugCreator([
-      DiagnosticsDebugCreator(this),
-    ]);
+    final diagnosticsNodes = debugTransformDebugCreator([DiagnosticsDebugCreator(this)]);
     return diagnosticsNodes.map((e) => e.toStringDeep()).join('\n');
   }
 }

--- a/lib/src/checkers/minimum_tap_area_checker.dart
+++ b/lib/src/checkers/minimum_tap_area_checker.dart
@@ -128,6 +128,16 @@ Icon(
       return View.maybeOf(creator.element);
     }
 
+    // debugCreator is only populated in debug mode. In release mode, walk the
+    // render tree to find the owning RenderView.
+    RenderObject? current = renderObject.parent;
+    while (current != null) {
+      if (current is RenderView) {
+        return current.flutterView;
+      }
+      current = current.parent;
+    }
+
     return null;
   }
 

--- a/test/enable_accessibility_controls_on_release_mode_test.dart
+++ b/test/enable_accessibility_controls_on_release_mode_test.dart
@@ -10,11 +10,11 @@ void main() {
     AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
-  testWidgets('enableAccessibilityControlsOnReleaseMode allows accessibility controls to be visible', (WidgetTester tester) async {
+  testWidgets('enableInReleaseMode allows accessibility controls to be visible', (WidgetTester tester) async {
     // Create an app with accessibility controls enabled in release mode
     await tester.pumpWidget(
       MaterialApp(
-        builder: (context, child) => AccessibilityTools(child: child, enableAccessibilityControlsOnReleaseMode: true, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
+        builder: (context, child) => AccessibilityTools(child: child, enableInReleaseMode: true, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
         home: Scaffold(
           body: GestureDetector(
             onTap: () {},
@@ -30,10 +30,10 @@ void main() {
     expect(find.byType(Scaffold), findsOneWidget);
   });
 
-  testWidgets('Accessibility controls work normally when enableAccessibilityControlsOnReleaseMode is false', (WidgetTester tester) async {
+  testWidgets('Accessibility controls work normally when enableInReleaseMode is false', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        builder: (context, child) => AccessibilityTools(child: child, enableAccessibilityControlsOnReleaseMode: false, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
+        builder: (context, child) => AccessibilityTools(child: child, enableInReleaseMode: false, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
         home: Scaffold(
           body: GestureDetector(
             onTap: () {},
@@ -49,11 +49,11 @@ void main() {
     expect(find.byType(Scaffold), findsOneWidget);
   });
 
-  testWidgets('Default value of enableAccessibilityControlsOnReleaseMode is false', (WidgetTester tester) async {
-    // Create an AccessibilityTools without specifying enableAccessibilityControlsOnReleaseMode
+  testWidgets('Default value of enableInReleaseMode is false', (WidgetTester tester) async {
+    // Create an AccessibilityTools without specifying enableInReleaseMode
     final tools = AccessibilityTools(child: Container());
 
     // Verify the default value is false
-    expect(tools.enableAccessibilityControlsOnReleaseMode, isFalse);
+    expect(tools.enableInReleaseMode, isFalse);
   });
 }

--- a/test/enable_accessibility_controls_on_release_mode_test.dart
+++ b/test/enable_accessibility_controls_on_release_mode_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:accessibility_tools/accessibility_tools.dart';
+
+void main() {
+  setUp(() {
+    AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
+  });
+
+  testWidgets(
+    'enableAccessibilityControlsOnReleaseMode allows accessibility controls to be visible',
+    (WidgetTester tester) async {
+      // Create an app with accessibility controls enabled in release mode
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) => AccessibilityTools(
+            child: child,
+            enableAccessibilityControlsOnReleaseMode: true,
+            checkSemanticLabels: true,
+            minimumTapAreas: MinimumTapAreas.material,
+          ),
+          home: Scaffold(
+            body: GestureDetector(
+              onTap: () {},
+              child: SizedBox(
+                width: 10,
+                height: 10,
+                child: Container(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // The app should render without issues
+      expect(find.byType(Scaffold), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Accessibility controls work normally when enableAccessibilityControlsOnReleaseMode is false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) => AccessibilityTools(
+            child: child,
+            enableAccessibilityControlsOnReleaseMode: false,
+            checkSemanticLabels: true,
+            minimumTapAreas: MinimumTapAreas.material,
+          ),
+          home: Scaffold(
+            body: GestureDetector(
+              onTap: () {},
+              child: SizedBox(
+                width: 10,
+                height: 10,
+                child: Container(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // The app should render without issues
+      expect(find.byType(Scaffold), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Default value of enableAccessibilityControlsOnReleaseMode is false',
+    (WidgetTester tester) async {
+      // Create an AccessibilityTools without specifying enableAccessibilityControlsOnReleaseMode
+      final tools = AccessibilityTools(
+        child: Container(),
+      );
+
+      // Verify the default value is false
+      expect(tools.enableAccessibilityControlsOnReleaseMode, isFalse);
+    },
+  );
+}

--- a/test/enable_accessibility_controls_on_release_mode_test.dart
+++ b/test/enable_accessibility_controls_on_release_mode_test.dart
@@ -1,8 +1,6 @@
-import 'package:flutter/foundation.dart';
+import 'package:accessibility_tools/accessibility_tools.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:accessibility_tools/accessibility_tools.dart';
 
 void main() {
   setUp(() {
@@ -10,50 +8,69 @@ void main() {
     AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
   });
 
-  testWidgets('enableInReleaseMode allows accessibility controls to be visible', (WidgetTester tester) async {
-    // Create an app with accessibility controls enabled in release mode
-    await tester.pumpWidget(
-      MaterialApp(
-        builder: (context, child) => AccessibilityTools(child: child, enableInReleaseMode: true, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
-        home: Scaffold(
-          body: GestureDetector(
-            onTap: () {},
-            child: SizedBox(width: 10, height: 10, child: Container()),
+  testWidgets(
+    'enableInReleaseMode allows accessibility controls to be visible',
+    (WidgetTester tester) async {
+      // Create an app with accessibility controls enabled in release mode
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) => AccessibilityTools(
+            enableInReleaseMode: true,
+            checkSemanticLabels: true,
+            minimumTapAreas: MinimumTapAreas.material,
+            child: child,
+          ),
+          home: Scaffold(
+            body: GestureDetector(
+              onTap: () {},
+              child: SizedBox(width: 10, height: 10, child: Container()),
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-    // The app should render without issues
-    expect(find.byType(Scaffold), findsOneWidget);
-  });
+      // The app should render without issues
+      expect(find.byType(Scaffold), findsOneWidget);
+    },
+  );
 
-  testWidgets('Accessibility controls work normally when enableInReleaseMode is false', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        builder: (context, child) => AccessibilityTools(child: child, enableInReleaseMode: false, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
-        home: Scaffold(
-          body: GestureDetector(
-            onTap: () {},
-            child: SizedBox(width: 10, height: 10, child: Container()),
+  testWidgets(
+    'Accessibility controls work normally when enableInReleaseMode is false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) => AccessibilityTools(
+            enableInReleaseMode: false,
+            checkSemanticLabels: true,
+            minimumTapAreas: MinimumTapAreas.material,
+            child: child,
+          ),
+          home: Scaffold(
+            body: GestureDetector(
+              onTap: () {},
+              child: SizedBox(width: 10, height: 10, child: Container()),
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-    // The app should render without issues
-    expect(find.byType(Scaffold), findsOneWidget);
-  });
+      // The app should render without issues
+      expect(find.byType(Scaffold), findsOneWidget);
+    },
+  );
 
-  testWidgets('Default value of enableInReleaseMode is false', (WidgetTester tester) async {
-    // Create an AccessibilityTools without specifying enableInReleaseMode
-    final tools = AccessibilityTools(child: Container());
+  testWidgets(
+    'Default value of enableInReleaseMode is false',
+    (WidgetTester tester) async {
+      // Create an AccessibilityTools without specifying enableInReleaseMode
+      final tools = AccessibilityTools(child: Container());
 
-    // Verify the default value is false
-    expect(tools.enableInReleaseMode, isFalse);
-  });
+      // Verify the default value is false
+      expect(tools.enableInReleaseMode, isFalse);
+    },
+  );
 }

--- a/test/enable_accessibility_controls_on_release_mode_test.dart
+++ b/test/enable_accessibility_controls_on_release_mode_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:accessibility_tools/accessibility_tools.dart';
+
+void main() {
+  setUp(() {
+    AccessibilityTools.debugRunCheckersInTests = true;
+    AccessibilityTools.debugIgnoreTapAreaIssuesInTools = false;
+  });
+
+  testWidgets('enableAccessibilityControlsOnReleaseMode allows accessibility controls to be visible', (WidgetTester tester) async {
+    // Create an app with accessibility controls enabled in release mode
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) => AccessibilityTools(child: child, enableAccessibilityControlsOnReleaseMode: true, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
+        home: Scaffold(
+          body: GestureDetector(
+            onTap: () {},
+            child: SizedBox(width: 10, height: 10, child: Container()),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // The app should render without issues
+    expect(find.byType(Scaffold), findsOneWidget);
+  });
+
+  testWidgets('Accessibility controls work normally when enableAccessibilityControlsOnReleaseMode is false', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) => AccessibilityTools(child: child, enableAccessibilityControlsOnReleaseMode: false, checkSemanticLabels: true, minimumTapAreas: MinimumTapAreas.material),
+        home: Scaffold(
+          body: GestureDetector(
+            onTap: () {},
+            child: SizedBox(width: 10, height: 10, child: Container()),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // The app should render without issues
+    expect(find.byType(Scaffold), findsOneWidget);
+  });
+
+  testWidgets('Default value of enableAccessibilityControlsOnReleaseMode is false', (WidgetTester tester) async {
+    // Create an AccessibilityTools without specifying enableAccessibilityControlsOnReleaseMode
+    final tools = AccessibilityTools(child: Container());
+
+    // Verify the default value is false
+    expect(tools.enableAccessibilityControlsOnReleaseMode, isFalse);
+  });
+}


### PR DESCRIPTION
# Allow accessibility_tools to run in release mode

## Widgetbook use case

[Widgetbook](https://pub.dev/packages/widgetbook) is a Flutter package for cataloguing and
visually testing UI components in isolation, similar to Storybook for web. Widgetbook apps
are commonly compiled and deployed as **release builds** — either as a standalone web app
or as a separate Flutter app distributed to designers and QA teams.

Before this change, `AccessibilityTools` was entirely inert in those builds, making it
useless in the exact environment where designers are reviewing components.

With `enableInReleaseMode: true`, teams can wrap their Widgetbook component tree with
`AccessibilityTools` and get live accessibility feedback while browsing components in the
catalogue, even when the Widgetbook app is deployed as a release build:

```dart
// widgetbook/lib/main.dart
@widgetbook.App()
class WidgetbookApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Widgetbook.material(
      appBuilder: (context, child) => AccessibilityTools(
        enableInReleaseMode: true, // ← enables checkers in the deployed Widgetbook
        child: child,
      ),
      // ...
    );
  }
}
```

This allows the accessibility overlay to flag issues — missing semantic labels, tap areas
that are too small, missing input labels — directly inside the Widgetbook UI, giving
designers and QA engineers the same feedback loop that developers have locally in debug
mode.

## Background

Previously, `AccessibilityTools` was unconditionally disabled in release mode. The widget
would short-circuit in `build()` and return the child directly whenever `kReleaseMode` was
`true`. This made it impossible to verify accessibility compliance in release builds, where
certain behaviours (layout, font rendering, pixel density) can differ from debug builds.

## What changed

### 1. New `enableInReleaseMode` flag (`AccessibilityTools`)

A new boolean parameter `enableInReleaseMode` (default `false`) was added to
`AccessibilityTools`. When set to `true`, the widget bypasses the release-mode guard and
runs all checkers normally:

```dart
AccessibilityTools(
  enableInReleaseMode: true,
  child: child,
)
```

The build guard was refactored from a bare `kReleaseMode` check into an explicit variable
for clarity:

```dart
final shouldDisableAccessibilityTools =
    (kReleaseMode && !widget.enableInReleaseMode) ||
    (!AccessibilityTools.debugRunCheckersInTests && _isTest);
```

### 2. Suppressed debug logs in release mode (`CheckerManager`)

`CheckerManager` received a new `debugLogsEnabled` parameter. In release mode (even with
`enableInReleaseMode: true`), printing `debugPrint` output that references `DebugCreator`
or widget source locations would be misleading or crash-prone, because those structures are
stripped by the compiler. The flag is set to `false` when running in release mode:

```dart
debugLogsEnabled: !kReleaseMode || !widget.enableInReleaseMode
```

`_logAccessibilityIssues` respects it:

```dart
if (logLevel == LogLevel.none || !debugLogsEnabled) return;
```

Issues are still detected and shown in the UI overlay — only the console output is
suppressed.

### 3. Fixed `MinimumTapAreaChecker` silently skipping all nodes in release mode

This is the most important correctness fix. `MinimumTapAreaChecker._flutterViewForRenderObject`
previously obtained the `FlutterView` by reading `RenderObject.debugCreator`:

```dart
final creator = renderObject.debugCreator; // always null in release mode
if (creator is DebugCreator) {
  return View.maybeOf(creator.element);
}
return null; // ← always reached in release mode
```

Because `debugCreator` is set inside an `assert(...)` block in Flutter's
`RenderObjectElement`, it is **always `null` in release mode** regardless of the
`enableInReleaseMode` flag. The caller treated `window == null` as a signal to skip the
node entirely, so **no tap-area issues were ever detected** when running in release mode.

The fix adds a fallback that walks the render tree up to the `RenderView` root, which is
always present in both debug and release mode:

```dart
RenderObject? current = renderObject.parent;
while (current != null) {
  if (current is RenderView) {
    return current.flutterView;
  }
  current = current.parent;
}
```

`_contextForRenderObject` (used only for the `IgnoreMinimumTapAreaSize` opt-out) is
intentionally left as-is: in release mode it returns `null`, which safely skips the
opt-out check — a known and acceptable limitation.

### 4. Renamed `enableAccessibilityControlsOnReleaseMode` → `enableInReleaseMode`

The original parameter name was verbose and redundant given the widget it belongs to. The
new name is shorter and equally unambiguous within the context of `AccessibilityTools`.

## Test coverage

A new test file `test/enable_accessibility_controls_on_release_mode_test.dart` covers:

- `enableInReleaseMode: true` renders without exceptions
- `enableInReleaseMode: false` (explicit) renders without exceptions
- Default value of `enableInReleaseMode` is `false`
